### PR TITLE
Minor updates for native

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         'coroutines': '1.2.1',
         'dokka': '0.9.18',
         'kotlin': '1.3.31',
-        'stately': '0.7.0'
+        'stately': '0.7.2'
     ]
 
     dependencies {

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -77,14 +77,14 @@ actual class CoroutineWorker {
     actual companion object {
 
         /**
-         * Sets the handler for uncaught exceptions encountered during CoroutineWorker.execute
+         * Gets the number of active workers running in the underlying WorkerPool.
+         * This is useful when testing, to ensure you don't leave workers running
+         * across tests.
          */
-        fun setUnhandledExceptionHook(handler: (Throwable) -> Unit) {
-            BackgroundCoroutineWorkQueueExecutor.setUnhandledExceptionHook(handler)
-        }
+        val numActiveWorkers: Int
+            get() = executor.numActiveWorkers
 
         /** The executor used for all BackgroundJobs */
-        @SharedImmutable
         private val executor = BackgroundCoroutineWorkQueueExecutor<WorkItem>(4)
 
         actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {


### PR DESCRIPTION
- Ensure futures are periodically consumed and cleaned up
- Add a `val` for getting the number of active workers (useful for testing)
- Expose uncaught exception hook for background Workers