### PR TITLE
Upgrade gradle and kotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,11 +3,11 @@ import org.jetbrains.kotlin.konan.target.HostManager
 
 val coroutinesVersion by extra("1.2.2")
 val dokkaVersion by extra("0.9.18")
-val kotlinVersion by extra("1.3.40")
+val kotlinVersion by extra("1.3.41")
 val statelyVersion by extra("0.7.3")
 
 plugins {
-    kotlin("multiplatform") version "1.3.40"
+    kotlin("multiplatform") version "1.3.41"
     id("org.jetbrains.dokka") version "0.9.18"
     id("maven-publish")
     id("signing")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip


### PR DESCRIPTION
This upgrades gradle to 5.5 and kotlin to 1.3.41 (fixes issue with new type-inference engine and `threadSafeSuspendCallback`).