### PR TITLE
Improve and simplify performAndWait

### DIFF
--- a/src/commonMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/commonMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -1,6 +1,8 @@
 package com.autodesk.coroutineworker
 
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 /**
  * Encapsulates performing background work. On JVM, this use coroutines outright.
@@ -31,7 +33,18 @@ expect class CoroutineWorker {
          * and returns the result of that background work back to the calling thread
          *
          * @param block The work block to execute in the background
+         * @param newCoroutineContext The context, in which to execute the block. This is only used on JVM,
+         *                         so that JVM can take advantage of utilizing other Dispatchers like Dispatchers.IO
          */
-        suspend fun <T> performAndWait(block: suspend CoroutineScope.() -> T): T
+        suspend fun <T> performAndWait(newCoroutineContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T
     }
 }
+
+/**
+ * Enqueues the background work to run, suspends while the work is in progress,
+ * and returns the result of that background work back to the calling thread.
+ * This always passes Dispatchers.Default as the newCoroutineContext for JVM.
+ *
+ * @param block The work block to execute in the background
+ */
+suspend fun <T> CoroutineWorker.Companion.performAndWait(block: suspend CoroutineScope.() -> T) = performAndWait(Dispatchers.Default, block)

--- a/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -4,8 +4,8 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 actual class CoroutineWorker : CoroutineScope {
 
@@ -24,23 +24,14 @@ actual class CoroutineWorker : CoroutineScope {
     actual companion object {
 
         actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
-            return CoroutineWorker().also {
-                it.launch(block = block)
+            return CoroutineWorker().apply {
+                launch(block = block)
             }
         }
 
-        actual suspend fun <T> performAndWait(block: suspend CoroutineScope.() -> T): T {
+        actual suspend fun <T> performAndWait(newCoroutineContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return CoroutineWorker().run {
-                val channel = Channel<Result<T>>()
-                launch {
-                    val result = runCatching {
-                        block()
-                    }
-                    channel.send(result)
-                }
-                val result = channel.receive()
-                channel.close()
-                result.getOrThrow()
+                withContext(newCoroutineContext, block)
             }
         }
     }

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -97,15 +97,15 @@ actual class CoroutineWorker {
             }
         }
 
-        actual suspend fun <T> performAndWait(block: suspend CoroutineScope.() -> T): T {
+        actual suspend fun <T> performAndWait(newCoroutineContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return threadSafeSuspendCallback<T> { completion ->
-                execute {
+                val job = execute {
                     val result = runCatching {
                         block()
                     }
                     completion(result)
                 }
-                return@threadSafeSuspendCallback { Unit }
+                return@threadSafeSuspendCallback { job.cancel() }
             }
         }
 


### PR DESCRIPTION
- ~Simplify threadSafeSuspendCallback~ fixed in #23 
- ~Ensure performAndWait responds to cancellation~ fixed in #24 
- ~Allow passing Dispatcher for JVM~ fixed in #25