### PR TITLE
Fix withContext child cancellation

### DIFF
--- a/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
+++ b/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
@@ -29,7 +29,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `performAndWait across threads`() {
+    fun `withContext across threads`() {
         testRunBlocking {
             val ran = CoroutineWorker.withContext(Dispatchers.Default) {
                 CoroutineWorker.withContext(Dispatchers.Default) {
@@ -92,7 +92,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `can return null values from performAndWait`() {
+    fun `can return null values from withContext`() {
         testRunBlocking {
             val value: Unit? = CoroutineWorker.withContext(Dispatchers.Default) {
                 delay(20)
@@ -103,12 +103,12 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `cancellation works across performAndWait boundary`() {
+    fun `cancellation works across withContext boundary`() {
         testRunBlocking {
             val pwRunning = AtomicBoolean(false)
             val pwCancelled = AtomicBoolean(false)
             val job = CoroutineWorker.execute {
-                CoroutineWorker.performAndWait {
+                CoroutineWorker.withContext(Dispatchers.Default) {
                     var jobNotifiedStarted = false
                     while (true) {
                         try {

--- a/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
+++ b/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
@@ -101,6 +101,34 @@ class CoroutineWorkerTest {
             assertNull(value)
         }
     }
+
+    @Test
+    fun `cancellation works across performAndWait boundary`() {
+        testRunBlocking {
+            val pwRunning = AtomicBoolean(false)
+            val pwCancelled = AtomicBoolean(false)
+            val job = CoroutineWorker.execute {
+                CoroutineWorker.performAndWait {
+                    var jobNotifiedStarted = false
+                    while (true) {
+                        try {
+                            delay(20)
+                        } catch (e: CancellationException) {
+                            pwCancelled.value = true
+                            throw e
+                        }
+                        if (!jobNotifiedStarted) {
+                            pwRunning.value = true
+                            jobNotifiedStarted = true
+                        }
+                    }
+                }
+            }
+            busyWaitForCondition { pwRunning.value }
+            job.cancelAndJoin()
+            busyWaitForCondition { pwCancelled.value }
+        }
+    }
 }
 
 private suspend fun busyWaitForCondition(cond: () -> Boolean) {

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/BackgroundCoroutineWorkQueueExecutor.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/BackgroundCoroutineWorkQueueExecutor.kt
@@ -7,6 +7,7 @@ import co.touchlab.stately.concurrency.value
 import co.touchlab.stately.concurrency.withLock
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.SharedImmutable
+import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -75,6 +76,8 @@ internal class BackgroundCoroutineWorkQueueExecutor<WorkItem : CoroutineWorkItem
         if (activeWorkerCount < numWorkers) {
             pool.performWork {
                 runBlocking {
+                    // error if we accidentally freeze coroutine internals
+                    this.ensureNeverFrozen()
                     processWorkItems()
                 }
             }

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -99,13 +99,13 @@ actual class CoroutineWorker {
 
         actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return threadSafeSuspendCallback<T> { completion ->
-                execute {
+                val job = execute {
                     val result = runCatching {
                         block()
                     }
                     completion(result)
                 }
-                return@threadSafeSuspendCallback { Unit }
+                return@threadSafeSuspendCallback { job.cancel() }
             }
         }
 


### PR DESCRIPTION
This is a standalone PR for this change in #22. This makes performAndWait cancel it's child work, if the originating coroutine is cancelled.