### PR TITLE
Deprecate performAndWait for withContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ worker.cancelAndJoin()
 
 ### Waiting on Asynchronous Work to Complete
 
-From a coroutine context (i.e. somewhere you can call a `suspend fun`), use `performAndWait` to kick off work to another thread. It will non-blocking/suspend wait for the cross-thread work to complete:
+From a coroutine context (i.e. somewhere you can call a `suspend fun`), use `withContext` to kick off work to another thread. It will non-blocking/suspend wait for the cross-thread work to complete:
 
 ```kotlin
 suspend fun doWork() {
-  val result = CoroutineWorker.performAndWait {
+  val result = CoroutineWorker.withContext {
     // This is similar to execute, but it returns
     // the result of the work at the end of this lambda
     1
@@ -48,6 +48,7 @@ suspend fun doWork() {
 }
 ```
 
+This is like using `withContext` on JVM to switch coroutine contexts. You can also properly pass a dispatcher, which will be used on JVM: `withContext(Dispatchers.IO) { … }`. The idea here is that this will be easy to migrate when we do get multi-threaded coroutine support in Kotlin/Native.
 
 ### Waiting on Asynchronous Callback-based Work
 
@@ -73,7 +74,7 @@ suspend fun performNetworkFetch() {
 Object detachment (i.e. [transferring object ownership](https://github.com/JetBrains/kotlin-native/blob/master/CONCURRENCY.md#object-transfer-and-freezing) from one thread to another) is relatively difficult to achieve (outside of simple scenarios) compared to working with objects that are frozen and immutable. Because of this, CoroutineWorker prefers taking the frozen, immutable route:
 
 - Lambdas passed to CoroutineWorker are automatically frozen when they are going to be passed across threads.
-- The result value from `performAndWait` is also frozen.
+- The result value from `withContext` is also frozen.
 
 ### Tips for Working with Frozen State
 

--- a/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
+++ b/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -30,8 +31,8 @@ class CoroutineWorkerTest {
     @Test
     fun `performAndWait across threads`() {
         testRunBlocking {
-            val ran = CoroutineWorker.performAndWait {
-                CoroutineWorker.performAndWait {
+            val ran = CoroutineWorker.withContext(Dispatchers.Default) {
+                CoroutineWorker.withContext(Dispatchers.Default) {
                     async { true }.await()
                 }
             }
@@ -93,7 +94,7 @@ class CoroutineWorkerTest {
     @Test
     fun `can return null values from performAndWait`() {
         testRunBlocking {
-            val value: Unit? = CoroutineWorker.performAndWait {
+            val value: Unit? = CoroutineWorker.withContext(Dispatchers.Default) {
                 delay(20)
                 null
             }

--- a/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -4,7 +4,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 
 actual class CoroutineWorker : CoroutineScope {
@@ -29,18 +28,9 @@ actual class CoroutineWorker : CoroutineScope {
             }
         }
 
-        actual suspend fun <T> performAndWait(block: suspend CoroutineScope.() -> T): T {
-            return CoroutineWorker().run {
-                val channel = Channel<Result<T>>()
-                launch {
-                    val result = runCatching {
-                        block()
-                    }
-                    channel.send(result)
-                }
-                val result = channel.receive()
-                channel.close()
-                result.getOrThrow()
+        actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+            return kotlinx.coroutines.withContext(jvmContext) {
+                block()
             }
         }
     }

--- a/src/jvmTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerJVMTest.kt
+++ b/src/jvmTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerJVMTest.kt
@@ -1,0 +1,26 @@
+package com.autodesk.coroutineworker
+
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.junit.Test
+
+class CoroutineWorkerJVMTest {
+
+    @Test
+    fun `test withContext changes contexts`() {
+        testRunBlocking {
+            var called = false
+            val job = launch {
+                val context = coroutineContext
+                CoroutineWorker.withContext(Dispatchers.IO) {
+                    assertNotSame(context, coroutineContext)
+                    called = true
+                }
+            }
+            job.join()
+            assertTrue(called)
+        }
+    }
+}

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -97,7 +97,7 @@ actual class CoroutineWorker {
             }
         }
 
-        actual suspend fun <T> performAndWait(block: suspend CoroutineScope.() -> T): T {
+        actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return threadSafeSuspendCallback<T> { completion ->
                 execute {
                     val result = runCatching {


### PR DESCRIPTION
`performAndWait` was roughly the same as `withContext`, but the previous API didn't allow the JVM to take advantage of actual context switching, which is possible in that env. With the new API, you can pass `Dispatchers.IO`, and it'll work as expected in JVM.