### PR TITLE
Ensure threadSafeSuspendCallback completion frozen

### DIFF
--- a/src/nativeTest/kotlin/com/autodesk/coroutineworker/CoroutineUtilsTest.kt
+++ b/src/nativeTest/kotlin/com/autodesk/coroutineworker/CoroutineUtilsTest.kt
@@ -1,0 +1,22 @@
+package com.autodesk.coroutineworker
+
+import kotlin.native.concurrent.isFrozen
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CoroutineUtilsTest {
+
+    @Test
+    fun `threadSafeSuspendCallback completion is frozen`() {
+        testRunBlocking {
+            var called = false
+            threadSafeSuspendCallback<Unit> { completion ->
+                called = true
+                assertTrue(completion.isFrozen)
+                completion(Result.success(Unit))
+                return@threadSafeSuspendCallback { Unit }
+            }
+            assertTrue(called)
+        }
+    }
+}


### PR DESCRIPTION
In the refactor in #23, I forgot to freeze the internal completion handler that's created. This fixes that and adds a test.