### PR TITLE
Build gradle and dokka improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinTest
 import org.jetbrains.kotlin.konan.target.HostManager
 
 val coroutinesVersion by extra("1.3.3")
-val dokkaVersion by extra("0.9.18")
 val atomicfuVersion by extra("0.14.1")
 
 plugins {
     kotlin("multiplatform") version "1.3.61"
-    id("org.jetbrains.dokka") version "0.9.18"
+    id("org.jetbrains.dokka") version "0.10.0"
     id("maven-publish")
     id("signing")
 }
@@ -130,15 +129,6 @@ if (HostManager.hostIsMac) {
 
     checkTask.configure {
         dependsOn(testIosSim)
-    }
-}
-
-if (HostManager.hostIsMingw) {
-    val mingwTestTask = tasks.named<KotlinTest>("mingwX64Test")
-    mingwTestTask.configure {
-        // workaround for https://youtrack.jetbrains.net/issue/KT-33246
-        // remove at Kotlin 1.3.60
-        binaryResultsDirectory.set(binResultsDir)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,13 @@ repositories {
 
 kotlin {
     targets {
-        jvm()
+        jvm {
+            compilations.all {
+                kotlinOptions {
+                    jvmTarget = "1.8"
+                }
+            }
+        }
         iosX64()
         iosArm64()
         iosArm32()
@@ -32,27 +38,26 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
+                implementation(kotlin("stdlib-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$coroutinesVersion")
             }
         }
         commonTest {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-test-common")
-                implementation("org.jetbrains.kotlin:kotlin-test-annotations-common")
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$coroutinesVersion")
                 implementation("org.jetbrains.kotlinx:atomicfu-native:$atomicfuVersion")
             }
         }
         val jvmMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-stdlib")
+                implementation(kotlin("stdlib-jdk8"))
             }
         }
         val jvmTest by getting {
             dependencies {
-                implementation("org.jetbrains.kotlin:kotlin-test")
-                implementation("org.jetbrains.kotlin:kotlin-test-junit")
+                implementation(kotlin("test-junit"))
             }
         }
         val nativeMain by creating {}

--- a/publish.gradle
+++ b/publish.gradle
@@ -8,32 +8,22 @@ group 'com.autodesk'
 version getDeployVersion()
 
 dokka {
-    impliedPlatforms = ['Common'] // This will force platform tags for all non-common sources e.g. 'JVM'
-    kotlinTasks {
-        // dokka fails to retrieve sources from MPP-tasks so they must be set empty to avoid exception
-        // use sourceRoot instead (see below)
-        []
-    }
-    packageOptions {
-        prefix = project.group
-    }
-    sourceRoot {
-        // assuming there is only a single source dir...
-        path = kotlin.sourceSets.commonMain.kotlin.srcDirs[0]
-        platforms = ['Common']
-    }
-    if (kotlin.sourceSets.getNames().contains('jvmMain')) {
-        sourceRoot {
-            // assuming there is only a single source dir...
-            path = kotlin.sourceSets.jvmMain.kotlin.srcDirs[0]
-            platforms = ['JVM']
+    multiplatform {
+        global {
+            perPackageOption {
+                prefix = project.group
+            }
         }
-    }
-    if (kotlin.sourceSets.getNames().contains('nativeMain')) {
-        sourceRoot {
-            // assuming there is only a single source dir...
-            path = kotlin.sourceSets.nativeMain.kotlin.srcDirs[0]
-            platforms = ['native']
+        common {}
+        jvm {}
+        register("native") {
+            platform = "native"
+            sourceRoot {
+                path = kotlin.sourceSets.nativeMain.kotlin.srcDirs[0]
+            }
+            sourceRoot {
+                path = kotlin.sourceSets.commonMain.kotlin.srcDirs[0]
+            }
         }
     }
 }

--- a/src/commonMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/commonMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Dispatchers
  * Encapsulates performing background work. On JVM, this use coroutines outright.
  * In native, this uses Worker threads and manages its mutability/concurrency issues.
  */
-expect class CoroutineWorker {
+expect class CoroutineWorker internal constructor() {
 
     /** Cancels the underlying Job */
     fun cancel()
@@ -22,31 +22,21 @@ expect class CoroutineWorker {
     companion object {
 
         /**
-         * Enqueues the background work to run and returns a reference to the worker, which can be cancelled
-         *
-         * @param block The work block to execute in the background
+         * Enqueues the background work [block] to run and returns a reference to the worker, which can be cancelled
          */
         fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker
 
         /**
-         * Performs block in another CoroutineContext and waits for it to complete.
-         * This is similar to withContext in kotlinx.coroutines, with some caveats:
+         * Performs [block] in another [CoroutineContext] ([jvmContext]) and waits for it to complete.
+         * This is similar to [kotlinx.coroutines.withContext] with some caveats:
          *
-         * - Native: we cannot use kotlinx.coroutines.withContext because
+         * - Native: we cannot use [kotlinx.coroutines.withContext] because
          *           the global Dispatchers do not work properly. Therefore,
          *           the context argument is ignored, and the block is always
          *           run on some other Worker in the Worker pool. This is the
          *           most similar to switching contexts on JVM.
          *
-         * - JVM: This has the same behavior as calling withContext in the JVM
-         *
-         * In the future when kotlinx.coroutines has support for native multi-threaded
-         * coroutines, this will make it easy to transition to kotlinx.coroutines.withContext
-         *
-         * @param jvmContext The context to switch to for JVM targets. For example,
-         *                   you might want to use Dispatchers.IO, as you would normally
-         *                   when doing blocking IO (for example) with coroutines.
-         * @param block The work block to execute
+         * - JVM: This has the same behavior as calling [kotlinx.coroutines.withContext] in the JVM
          */
         suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T
     }

--- a/src/commonMain/kotlin/com/autodesk/coroutineworker/Utils.kt
+++ b/src/commonMain/kotlin/com/autodesk/coroutineworker/Utils.kt
@@ -2,10 +2,10 @@ package com.autodesk.coroutineworker
 /**
  * Bridges a platform's callback-based async method to coroutines,
  * ensuring that the coroutine is resumed on a thread appropriate
- * for the platform
+ * for the platform.
  *
- * @param startAsync The lambda that starts the work, calls the passed CompletionLambda lambda
- *                   when complete, and returns a lambda that can be called to cancel the async
- *                   work
+ * [startAsync] is called to start the work. It calls the passed [CompletionLambda]
+ * when complete, and returns a [CancellationLambda] that can be called to cancel the
+ * async work
  * */
 expect suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T

--- a/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -6,10 +6,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 
-actual class CoroutineWorker : CoroutineScope {
+actual class CoroutineWorker internal actual constructor() : CoroutineScope {
 
     private val job = Job()
 
+    /**
+     * The context of this scope. See [CoroutineScope.coroutineContext]
+     */
     override val coroutineContext: CoroutineContext = job
 
     actual fun cancel() {

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/BackgroundCoroutineWorkQueueExecutor.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/BackgroundCoroutineWorkQueueExecutor.kt
@@ -30,10 +30,8 @@ internal interface CoroutineWorkItem {
 }
 
 /**
- * An executor that runs blocks in a CoroutineScope on a background
- * Worker (via a WorkerPool)
- *
- * @property numWorkers The number of workers needed in the pool
+ * An executor that runs blocks in a [kotlinx.coroutines.CoroutineScope] on a background
+ * Worker in a pool with [numWorkers] workers.
  */
 internal class BackgroundCoroutineWorkQueueExecutor<WorkItem : CoroutineWorkItem>(private val numWorkers: Int) {
 

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
-actual class CoroutineWorker {
+actual class CoroutineWorker internal actual constructor() {
 
     /**
      * True, if the job was cancelled; false, otherwise.

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/WorkerPool.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/WorkerPool.kt
@@ -31,9 +31,7 @@ private class WeightedWorker(
 
 /**
  * A pool of Worker instances, which are used in order of least busy
- * and then least recently used.
- *
- * @property numWorkers the number of Worker instances to keep in the bool
+ * and then least recently used. The pool will have [numWorkers] workers.
  */
 internal class WorkerPool(private val numWorkers: Int) {
     /** The available workers */


### PR DESCRIPTION
- Upgraded dokka– using new multiplatform support
- Fixed jvm target to use jdk8
- Fix dependencies to use `kotlin(…)` dsl
- Remove mingw hack no longer needed in Kotlin 1.3.60