### PR TITLE
Throw exception if context doesn't support delay

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 import org.jetbrains.kotlin.gradle.tasks.KotlinTest
 import org.jetbrains.kotlin.konan.target.HostManager
@@ -27,28 +28,17 @@ kotlin {
                 }
             }
         }
-        iosX64 {
-            val main by compilations.getting {
-                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
-            }
-        }
-        iosArm64 {
-            val main by compilations.getting {
-                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
-            }
-        }
-        iosArm32 {
-            val main by compilations.getting {
-                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
-            }
-        }
-        macosX64 {
-            val main by compilations.getting {
-                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
-            }
-        }
-        mingwX64 {
-            val main by compilations.getting {
+
+        val nativeTargets = mutableListOf<KotlinNativeTarget>()
+
+        iosX64() { nativeTargets.add(this) }
+        iosArm64() { nativeTargets.add(this) }
+        iosArm32() { nativeTargets.add(this) }
+        macosX64() { nativeTargets.add(this) }
+        mingwX64() { nativeTargets.add(this) }
+
+        nativeTargets.forEach {
+            val main by it.compilations.getting {
                 kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,21 +27,41 @@ kotlin {
                 }
             }
         }
-        iosX64()
-        iosArm64()
-        iosArm32()
-        macosX64()
-        mingwX64()
+        iosX64 {
+            val main by compilations.getting {
+                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
+            }
+        }
+        iosArm64 {
+            val main by compilations.getting {
+                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
+            }
+        }
+        iosArm32 {
+            val main by compilations.getting {
+                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
+            }
+        }
+        macosX64 {
+            val main by compilations.getting {
+                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
+            }
+        }
+        mingwX64 {
+            val main by compilations.getting {
+                kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")
+            }
+        }
     }
 
     sourceSets {
-        commonMain {
+        val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$coroutinesVersion")
             }
         }
-        commonTest {
+        val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
@@ -59,8 +79,12 @@ kotlin {
                 implementation(kotlin("test-junit"))
             }
         }
-        val nativeMain by creating {}
-        val nativeTest by creating {}
+        val nativeMain by creating {
+            dependsOn(commonMain)
+        }
+        val nativeTest by creating {
+            dependsOn(commonTest)
+        }
 
         listOf("iosX64", "iosArm64", "iosArm32", "macosX64", "mingwX64").forEach {
             getByName("${it}Main") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 VERSION=0.4.2
+kotlin.mpp.enableGranularSourceSetsMetadata=true


### PR DESCRIPTION
This makes some minor gradle updates, adds an experimental flag for native (for the coroutines API being used internally), and throws an exception on native if you use a CoroutineDispatcher that doesn't work with `threadSafeSuspendCallback`. This fixes #46 