### PR TITLE
Fix coroutineworker name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "CoroutineWorker"
+rootProject.name = "coroutineworker"


### PR DESCRIPTION
When I set rootProject.name, I didn't think about how that would impact publishing. Once this lands, I can publish again, and the correct artifact will be updated