### PR TITLE
Added Java script support since it's very popular  :: taco emoji

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,16 @@ kotlin {
             }
         }
 
+        js {
+            compilations.all {
+                kotlinOptions {
+                    moduleKind = "commonjs"
+                }
+            }
+            browser()
+            nodejs()
+        }
+
         val nativeTargets = mutableListOf<KotlinNativeTarget>()
 
         iosX64 { nativeTargets.add(this) }
@@ -74,6 +84,11 @@ kotlin {
         }
         val nativeTest by creating {
             dependsOn(commonTest)
+        }
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
         }
 
         val appleMain by creating

--- a/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
+++ b/src/commonTest/kotlin/com/autodesk/coroutineworker/CoroutineWorkerTest.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 class CoroutineWorkerTest {
 
     @Test
-    fun `nested executes run with coroutines`() {
+    fun nested_executes_run_with_coroutines() {
         val ran = atomic(false)
         testRunBlocking {
             CoroutineWorker.execute {
@@ -28,7 +28,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `withContext across threads`() {
+    fun withContext_across_threads() {
         testRunBlocking {
             val ran = CoroutineWorker.withContext(Dispatchers.Default) {
                 CoroutineWorker.withContext(Dispatchers.Default) {
@@ -40,7 +40,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `job cancellation across threads`() {
+    fun job_cancellation_across_threads() {
         val started = atomic(false)
         val cancelled = atomic(false)
         testRunBlocking {
@@ -59,7 +59,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `cancelAndJoin waits for jobs to cancel`() {
+    fun cancelAndJoin_waits_for_jobs_to_cancel() {
         testRunBlocking {
             val innerJobRunning = atomic(false)
             val innerCancelled = atomic(false)
@@ -87,7 +87,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `can return null values from withContext`() {
+    fun can_return_null_values_from_withContext() {
         testRunBlocking {
             val value: Unit? = CoroutineWorker.withContext(Dispatchers.Default) {
                 delay(20)
@@ -98,7 +98,7 @@ class CoroutineWorkerTest {
     }
 
     @Test
-    fun `cancellation works across withContext boundary`() {
+    fun cancellation_works_across_withContext_boundary() {
         testRunBlocking {
             val pwRunning = atomic(false)
             val pwCancelled = atomic(false)

--- a/src/jsMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/jsMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -1,0 +1,40 @@
+package com.autodesk.coroutineworker
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+
+actual class CoroutineWorker internal actual constructor() : CoroutineScope {
+
+    private val job = Job()
+
+    /**
+     * The context of this scope. See [CoroutineScope.coroutineContext]
+     */
+    override val coroutineContext: CoroutineContext = job
+
+    actual fun cancel() {
+        job.cancel()
+    }
+
+    actual suspend fun cancelAndJoin() {
+        job.cancelAndJoin()
+    }
+
+    actual companion object {
+
+        actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
+            return CoroutineWorker().also {
+                it.launch(block = block)
+            }
+        }
+
+        actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+            return kotlinx.coroutines.withContext(jvmContext) {
+                block()
+            }
+        }
+    }
+}

--- a/src/jsMain/kotlin/com/autodesk/coroutineworker/Utils.kt
+++ b/src/jsMain/kotlin/com/autodesk/coroutineworker/Utils.kt
@@ -1,0 +1,16 @@
+package com.autodesk.coroutineworker
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
+    return suspendCancellableCoroutine { cont ->
+        val cancellable = startAsync {
+            if (!cont.isCancelled) {
+                cont.resumeWith(it)
+            }
+        }
+        cont.invokeOnCancellation {
+            cancellable()
+        }
+    }
+}

--- a/src/jsTest/kotlin/com/autodesk/coroutineworker/Platform.kt
+++ b/src/jsTest/kotlin/com/autodesk/coroutineworker/Platform.kt
@@ -1,0 +1,10 @@
+package com.autodesk.coroutineworker
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): dynamic = GlobalScope.promise { block() }
+
+actual fun Any.ensureNeverFrozen() = asDynamic()

--- a/src/jsTest/kotlin/com/autodesk/coroutineworker/Platform.kt
+++ b/src/jsTest/kotlin/com/autodesk/coroutineworker/Platform.kt
@@ -7,4 +7,4 @@ import kotlinx.coroutines.promise
 
 actual fun <T> runBlocking(context: CoroutineContext, block: suspend CoroutineScope.() -> T): dynamic = GlobalScope.promise { block() }
 
-actual fun Any.ensureNeverFrozen() = asDynamic()
+actual fun Any.ensureNeverFrozen() = Unit


### PR DESCRIPTION
 Added Java script support since it's very popular and 3rd parties libaries that support it will conflict with this great library.

Modified the build.gradle.kts file.

Created the module.

but the jsTest compilation fails in some situations (not building the library direct) since JS doesn't have runBlock { .. } and the tests should be replaced as described here in this issue:

https://youtrack.jetbrains.com/issue/KT-22228

java script runBlocking situation : 
https://github.com/Kotlin/kotlinx.coroutines/tree/native-mt#native