### PR TITLE
Use explicitApi mode. Remove deprecated API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ captures/
 .idea/
 !.idea/codeStyles/
 !.idea/copyright/
+!.idea/inspectionProfiles
 
 # ruby files
 .bundle

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="RedundantVisibilityModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
     targets {
         jvm {
             compilations.all {

--- a/src/commonMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/commonMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -1,30 +1,29 @@
 package com.autodesk.coroutineworker
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
 /**
  * Encapsulates performing background work. On JVM, this use coroutines outright.
  * In native, this uses Worker threads and manages its mutability/concurrency issues.
  */
-expect class CoroutineWorker internal constructor() {
+public expect class CoroutineWorker internal constructor() {
 
     /** Cancels the underlying Job */
-    fun cancel()
+    public fun cancel()
 
     /**
      * Cancel the underlying job/worker and waits for it
      * to receive its cancellation message or complete
      * */
-    suspend fun cancelAndJoin()
+    public suspend fun cancelAndJoin()
 
-    companion object {
+    public companion object {
 
         /**
          * Enqueues the background work [block] to run and returns a reference to the worker, which can be cancelled
          */
-        fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker
+        public fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker
 
         /**
          * Performs [block] in another [CoroutineContext] ([jvmContext]) and waits for it to complete.
@@ -38,12 +37,6 @@ expect class CoroutineWorker internal constructor() {
          *
          * - JVM: This has the same behavior as calling [kotlinx.coroutines.withContext] in the JVM
          */
-        suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T
+        public suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T
     }
 }
-
-@Deprecated(
-    "Use withContext instead, which allows JVM to take advantage of specifying a dispatcher, such as Dispatchers.IO",
-    ReplaceWith("CoroutineWorker.withContext(Dispatchers.Default, block)", "kotlinx.coroutines.Dispatchers")
-)
-suspend fun <T> CoroutineWorker.Companion.performAndWait(block: suspend CoroutineScope.() -> T) = withContext(Dispatchers.Default, block)

--- a/src/commonMain/kotlin/com/autodesk/coroutineworker/Helpers.kt
+++ b/src/commonMain/kotlin/com/autodesk/coroutineworker/Helpers.kt
@@ -4,7 +4,7 @@ package com.autodesk.coroutineworker
  * A convenience wrapper for threadSafeSuspendCallback, for when
  * you don't intend to resume the continuation with an exception
  * */
-suspend fun <T> threadSafeSuspendCallbackWithValue(startAsync: ((T) -> Unit) -> CancellationLambda): T {
+public suspend fun <T> threadSafeSuspendCallbackWithValue(startAsync: ((T) -> Unit) -> CancellationLambda): T {
     return threadSafeSuspendCallback { completion ->
         startAsync {
             completion(Result.success(it))

--- a/src/commonMain/kotlin/com/autodesk/coroutineworker/Utils.kt
+++ b/src/commonMain/kotlin/com/autodesk/coroutineworker/Utils.kt
@@ -8,4 +8,4 @@ package com.autodesk.coroutineworker
  * when complete, and returns a [CancellationLambda] that can be called to cancel the
  * async work
  * */
-expect suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T
+public expect suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T

--- a/src/jsMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/jsMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
-actual class CoroutineWorker internal actual constructor() : CoroutineScope {
+public actual class CoroutineWorker internal actual constructor() : CoroutineScope {
 
     private val job = Job()
 
@@ -15,23 +15,23 @@ actual class CoroutineWorker internal actual constructor() : CoroutineScope {
      */
     override val coroutineContext: CoroutineContext = job
 
-    actual fun cancel() {
+    public actual fun cancel() {
         job.cancel()
     }
 
-    actual suspend fun cancelAndJoin() {
+    public actual suspend fun cancelAndJoin() {
         job.cancelAndJoin()
     }
 
-    actual companion object {
+    public actual companion object {
 
-        actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
+        public actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
             return CoroutineWorker().also {
                 it.launch(block = block)
             }
         }
 
-        actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+        public actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return kotlinx.coroutines.withContext(jvmContext) {
                 block()
             }

--- a/src/jsMain/kotlin/com/autodesk/coroutineworker/Utils.kt
+++ b/src/jsMain/kotlin/com/autodesk/coroutineworker/Utils.kt
@@ -2,7 +2,7 @@ package com.autodesk.coroutineworker
 
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
+public actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
     return suspendCancellableCoroutine { cont ->
         val cancellable = startAsync {
             if (!cont.isCancelled) {

--- a/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/jvmMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
-actual class CoroutineWorker internal actual constructor() : CoroutineScope {
+public actual class CoroutineWorker internal actual constructor() : CoroutineScope {
 
     private val job = Job()
 
@@ -15,23 +15,23 @@ actual class CoroutineWorker internal actual constructor() : CoroutineScope {
      */
     override val coroutineContext: CoroutineContext = job
 
-    actual fun cancel() {
+    public actual fun cancel() {
         job.cancel()
     }
 
-    actual suspend fun cancelAndJoin() {
+    public actual suspend fun cancelAndJoin() {
         job.cancelAndJoin()
     }
 
-    actual companion object {
+    public actual companion object {
 
-        actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
+        public actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
             return CoroutineWorker().also {
                 it.launch(block = block)
             }
         }
 
-        actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+        public actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return kotlinx.coroutines.withContext(jvmContext) {
                 block()
             }

--- a/src/jvmMain/kotlin/com/autodesk/coroutineworker/Utils.kt
+++ b/src/jvmMain/kotlin/com/autodesk/coroutineworker/Utils.kt
@@ -2,7 +2,7 @@ package com.autodesk.coroutineworker
 
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
+public actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
     return suspendCancellableCoroutine { cont ->
         val cancellable = startAsync {
             if (!cont.isCancelled) {

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/BackgroundCoroutineWorkQueueExecutor.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/BackgroundCoroutineWorkQueueExecutor.kt
@@ -143,7 +143,7 @@ internal class BackgroundCoroutineWorkQueueExecutor<WorkItem : CoroutineWorkItem
  * Set [handler] for exceptions that would
  * be bubbled up to the underlying Worker
  */
-fun setUnhandledExceptionHook(handler: (Throwable) -> Unit) {
+public fun setUnhandledExceptionHook(handler: (Throwable) -> Unit) {
     BackgroundCoroutineWorkQueueExecutor.setUnhandledExceptionHook(handler)
 }
 

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineUtils.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineUtils.kt
@@ -16,7 +16,7 @@ internal suspend fun waitAndDelayForCondition(condition: () -> Boolean) {
 }
 
 @OptIn(kotlinx.coroutines.InternalCoroutinesApi::class)
-actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
+public actual suspend fun <T> threadSafeSuspendCallback(startAsync: (CompletionLambda<T>) -> CancellationLambda): T {
     check(coroutineContext[ContinuationInterceptor] is Delay) {
         """threadSafeSuspendCallback only works for CoroutineDispatchers that implement Delay.
             |Implement Delay for your dispatcher or use runBlocking.

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -8,14 +8,14 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.freeze
 
-actual class CoroutineWorker internal actual constructor() {
+public actual class CoroutineWorker internal actual constructor() {
 
     /**
      * True, if the job was cancelled; false, otherwise.
      */
     private val state = CoroutineWorkerState()
 
-    actual fun cancel() {
+    public actual fun cancel() {
         cancelIfRunning()
     }
 
@@ -28,7 +28,7 @@ actual class CoroutineWorker internal actual constructor() {
         return true
     }
 
-    actual suspend fun cancelAndJoin() {
+    public actual suspend fun cancelAndJoin() {
         if (!cancelIfRunning()) {
             return
         }
@@ -36,20 +36,20 @@ actual class CoroutineWorker internal actual constructor() {
         waitAndDelayForCondition { state.completed }
     }
 
-    actual companion object {
+    public actual companion object {
 
         /**
          * Gets the number of active workers running in the underlying WorkerPool.
          * This is useful when testing, to ensure you don't leave workers running
          * across tests.
          */
-        val numActiveWorkers: Int
+        public val numActiveWorkers: Int
             get() = executor.numActiveWorkers
 
         /** The executor used for all BackgroundJobs */
         private val executor = BackgroundCoroutineWorkQueueExecutor<WorkItem>(4)
 
-        actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
+        public actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
             return CoroutineWorker().also {
                 val state = it.state
                 executor.enqueueWork(
@@ -62,7 +62,7 @@ actual class CoroutineWorker internal actual constructor() {
             }
         }
 
-        actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
+        public actual suspend fun <T> withContext(jvmContext: CoroutineContext, block: suspend CoroutineScope.() -> T): T {
             return threadSafeSuspendCallback<T> { completion ->
                 val job = execute {
                     val result = runCatching {


### PR DESCRIPTION
- Enables explicitApi mode using the new DSL
- Removes the one deprecated API