### PR TITLE
Add linux support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
         iosArm32 { nativeTargets.add(this) }
         macosX64 { nativeTargets.add(this) }
         mingwX64 { nativeTargets.add(this) }
+        linuxX64 { nativeTargets.add(this) }
 
         nativeTargets.forEach {
             val main by it.compilations.getting {
@@ -80,7 +81,7 @@ kotlin {
             }
         }
 
-        listOf("iosX64", "iosArm64", "iosArm32", "macosX64", "mingwX64").forEach {
+        listOf("iosX64", "iosArm64", "iosArm32", "macosX64", "mingwX64", "linuxX64").forEach {
             getByName("${it}Main") {
                 dependsOn(nativeMain)
             }

--- a/src/linuxX64Main/kotlin/com/autodesk/coroutineworker/AutoreleasePool.kt
+++ b/src/linuxX64Main/kotlin/com/autodesk/coroutineworker/AutoreleasePool.kt
@@ -1,0 +1,3 @@
+package com.autodesk.coroutineworker
+
+internal actual inline fun <R> autoreleasepool(block: () -> R): R = block()


### PR DESCRIPTION
It appears that `publish.gradle` requires a linux publishing task. However, I do not know whether just adding the lines
```groovy
tasks.register('publicLinux') {
    dependsOn 'publicLinuxX64PublicationToMavenRepository'
}
```
is all that is required.