### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Publish Mac Artifacts
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macOS-11'
         run: ./gradlew publishMac --no-daemon --stacktrace
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
Deploy was broken because while it was pointing to the right version of macOS, I had not updated the check for if we run the Mac publish.