### PR TITLE
Use processor count for number of default workers on Apple targets

### DIFF
--- a/src/appleMain/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
+++ b/src/appleMain/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
@@ -1,0 +1,8 @@
+package com.autodesk.coroutineworker
+
+import kotlinx.cinterop.UnsafeNumber
+import platform.Foundation.NSProcessInfo
+
+@OptIn(UnsafeNumber::class)
+public actual fun getDefaultNumWorkers(): Int =
+    NSProcessInfo.processInfo.processorCount.toInt()

--- a/src/linuxX64Main/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
+++ b/src/linuxX64Main/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
@@ -1,0 +1,3 @@
+package com.autodesk.coroutineworker
+
+public actual fun getDefaultNumWorkers(): Int = 4

--- a/src/mingwX64Main/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
+++ b/src/mingwX64Main/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
@@ -1,0 +1,3 @@
+package com.autodesk.coroutineworker
+
+public actual fun getDefaultNumWorkers(): Int = 4

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/CoroutineWorker.kt
@@ -47,7 +47,7 @@ public actual class CoroutineWorker internal actual constructor() {
             get() = executor.numActiveWorkers
 
         /** The executor used for all BackgroundJobs */
-        private val executor = BackgroundCoroutineWorkQueueExecutor<WorkItem>(4)
+        private val executor = BackgroundCoroutineWorkQueueExecutor<WorkItem>(getDefaultNumWorkers())
 
         public actual fun execute(block: suspend CoroutineScope.() -> Unit): CoroutineWorker {
             return executeInternal(false, block)

--- a/src/nativeMain/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
+++ b/src/nativeMain/kotlin/com/autodesk/coroutineworker/DefaultNumWorkers.kt
@@ -1,0 +1,3 @@
+package com.autodesk.coroutineworker
+
+public expect fun getDefaultNumWorkers(): Int


### PR DESCRIPTION
Newer iPhones and iPads have 6 cores, current MacBooks 10. This change will use as much workers as there are processors. See issue #96.